### PR TITLE
Correct very minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ goal of `cloudapp` is to be simple and Unix-friendly.
     gem install cloudapp
     cloudapp list
     cloudapp bookmark http://douglasadams.com
-    cloduapp upload ~/Desktop/screenshot.png
+    cloudapp upload ~/Desktop/screenshot.png
 
 ### Examples
 


### PR DESCRIPTION
This is really really minor but I found a small typo, cloduapp instead of cloudapp.
