### PR TITLE
An initial pass at allowing drops to be downloaded

### DIFF
--- a/bin/cloudapp
+++ b/bin/cloudapp
@@ -57,7 +57,6 @@ def fetch_link drop, options
   $stderr.puts link unless $stdout.tty?
 end
 
-
 def print_error message
   $stderr.puts "! #{wrap(message, 78, '  ')}"
 end
@@ -123,15 +122,35 @@ def file_names options, input = $stdin
   stdin_file_names + options.arguments
 end
 
+def directory_name file_names
+  if Dir.exists?(file_names.last)
+    return file_names.delete(file_names.last)
+  end
+  Dir.pwd
+end
+
+def url? url
+  url =~ URI.regexp
+end
+
+def cloudapp_url? url
+  url? url and url =~ /cl\.ly/
+end
+
 def share file_names, options
   invalid_command if file_names.empty?
   authenticate
+
+  download_dir = directory_name(file_names)
 
   file_names.each do |arg|
     if File.exists? arg
       $stderr.print "Uploading #{File.basename(arg)}... "
       drop = service.upload(arg)
-    elsif arg =~ URI.regexp
+    elsif cloudapp_url? arg
+      $stderr.print "Downloading #{arg}... "
+      drop = service.download(arg, download_dir)
+    elsif url? arg
       $stderr.print "Bookmarking #{arg}... "
       drop = service.bookmark(arg)
     else


### PR DESCRIPTION
A super rough pass at adding download support for drops. So far constraints are that URLs are selected based on a `cl.ly` domain (based on our convos), and the last argument is optional to specify a target directory for the download.

:triumph::sweat_drops::clap:

I didn't get to look and see if you provide the account holders custom domain, if so, could add that as part of the `cloudapp_url?` filtering. :eyes:

Also, eventually perhaps an additional query to the API to provide drop data based on its slug. Currently only by ID a drop is served back. :question: 

Usuage:
`cloudapp http://cl.ly/3W0R2X0E1t1U http://cl.ly/472M040N3Z44 ~/Desktop`

Supports existing piping, and output from my testing...

```
Downloading http://cl.ly/3W0R2X0E1t1U... /Users/dan/Desktop/helmet-what.gif
Downloading http://cl.ly/472M040N3Z44... /Users/dan/Desktop/blinking-homer.gif
```
