### PR TITLE
Update typhoeus dependency for compatibility with newer rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and Ruby.
 
 ## Requirements
 
-`cloudapp` requires Ruby 1.9.3 or greater. Windows is not yet supported. If
+`cloudapp` requires Ruby 2.0.0 or greater. Windows is not yet supported. If
 you're willing to lend a hand, we'd love to officially support it.
 
 ### Ubuntu Requirements

--- a/cloudapp.gemspec
+++ b/cloudapp.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'leadlight',  '~> 0.1.0'
   s.add_dependency 'mime-types', '~> 1.19'
   s.add_dependency 'netrc',      '~> 0.7.7'
-  s.add_dependency 'typhoeus',   '~> 0.3.3'
+  s.add_dependency 'typhoeus',   '~> 0.7.0'
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development

--- a/lib/cloudapp/service.rb
+++ b/lib/cloudapp/service.rb
@@ -3,6 +3,7 @@ require 'cloudapp/authorized'
 require 'cloudapp/collection_json'
 require 'mime/types'
 require 'uri'
+require 'typhoeus/adapters/faraday'
 
 module CloudApp
   class Service


### PR DESCRIPTION
Solves #35. Updates typhoeus to use v0.7.0 to enable use with ruby <= 2.2.0. The original version was no longer compatible with the default ruby install on OS X Yosemite as the exports of the 'mkmf' module have changed. Tested with ruby v2.0.0 and v2.2.0.